### PR TITLE
[main] 네비게이터 가드 & 메인페이지 레이어 계층 분리 

### DIFF
--- a/src/api/fetch.ts
+++ b/src/api/fetch.ts
@@ -1,14 +1,9 @@
 import axios from "axios";
 
-export const BASE_URL = import.meta.env.VITE_API_URL;
+const isDevelopment = import.meta.env.MODE === "development";
+const baseURL = import.meta.env.VITE_API_URL;
 
-export const httpClient = axios.create({ baseURL: BASE_URL });
-
-/**
- * HTTP 클라이언트의 전역 Authorization 헤더를 구성한다.
- *
- * @param token 사용자 토큰정보
- */
-export const setDefaultsHeaderAuth = (token: string) => {
-  httpClient.defaults.headers.common.Authorization = `Bearer ${token}`;
-};
+export const httpClient = axios.create({
+  baseURL: isDevelopment ? undefined : baseURL,
+  withCredentials: true,
+});

--- a/src/common/hooks/useTypedNavigate.ts
+++ b/src/common/hooks/useTypedNavigate.ts
@@ -1,0 +1,23 @@
+import { useNavigate } from "react-router-dom";
+
+import { RouteParams } from "@routes/type";
+
+export const useTypedNavigate = () => {
+  const navigate = useNavigate();
+
+  return <Path extends keyof RouteParams>(
+    path: Path,
+    params?: RouteParams[Path],
+    options?: { replace?: boolean }
+  ) => {
+    let resolvedPath = path as string;
+
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        resolvedPath = resolvedPath.replace(`:${key}`, String(value));
+      });
+    }
+
+    navigate(resolvedPath, { replace: options?.replace });
+  };
+};

--- a/src/common/hooks/useTypedParams.ts
+++ b/src/common/hooks/useTypedParams.ts
@@ -1,0 +1,6 @@
+import { RouteParams } from "@routes/type";
+import { useParams } from "react-router-dom";
+
+export const useTypedParams = <T extends keyof RouteParams>() => {
+  return useParams<NonNullable<RouteParams[T]>>();
+};

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -12,10 +12,12 @@ export interface ButtonProps {
   onClick?: () => void;
   type?: "small" | "medium";
   fullWidth?: boolean;
+  /** 버튼 비활성화 여부 */
+  disabled?: boolean;
 }
 
 const StyledButton = styled.button<{ $fullWidth?: boolean }>`
-  position: relative; /* 아이콘 위치를 조정하기 위해 relative */
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-evenly;
@@ -43,6 +45,18 @@ const StyledButton = styled.button<{ $fullWidth?: boolean }>`
     background-color: ${({ theme }) => theme.colors.background.neutral1};
     transform: scale(1.01);
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    background-color: ${({ theme }) => theme.colors.background.neutral2};
+    transform: none;
+
+    &:hover {
+      background-color: ${({ theme }) => theme.colors.background.neutral2};
+      transform: none;
+    }
+  }
 `;
 
 const IconItem = styled.div``;
@@ -62,20 +76,20 @@ const Button: React.FC<ButtonProps> = ({
   onClick,
   type = "medium",
   fullWidth = false,
+  disabled = false,
 }) => {
   const ButtonComponent = type === "small" ? SmallStyledButton : StyledButton;
   const width = calcResponsive({ value: 48, dimension: "width" });
   const height = calcResponsive({ value: 48, dimension: "height" });
 
   return (
-    <ButtonComponent onClick={onClick} $fullWidth={fullWidth}>
+    <ButtonComponent onClick={onClick} $fullWidth={fullWidth} disabled={disabled}>
       {Icon && (
         <IconItem>
           <Icon width={width} height={height} />
         </IconItem>
       )}
       <span>{label}</span>
-      {/* 간격 조정용 */}
       {Icon && (
         <IconItem style={{ visibility: "hidden" }}>
           <Icon width={width} height={height} />

--- a/src/components/card/StartPlannerCard.tsx
+++ b/src/components/card/StartPlannerCard.tsx
@@ -9,14 +9,11 @@ import FormField from "@components/field/FormField";
 interface Props {
   onClickPlanner: () => void;
   onSubmit: (code: string) => void;
+  placeholder?: string;
 }
 
-const StartPlannerCard: FC<Props> = ({ onClickPlanner, onSubmit }) => {
+const StartPlannerCard: FC<Props> = ({ onClickPlanner, onSubmit, placeholder }) => {
   const [code, setCode] = useState("");
-
-  const onSubmitHandler = () => {
-    return onSubmit(code);
-  };
 
   return (
     <Container>
@@ -28,8 +25,13 @@ const StartPlannerCard: FC<Props> = ({ onClickPlanner, onSubmit }) => {
       <Button label="플래너 시작하기" fullWidth onClick={onClickPlanner} />
       <Divider />
       <SubmitContainer>
-        <FormField.Input label={code} onChange={setCode} />
-        <Button label="참여하기" type="small" onClick={onSubmitHandler} />
+        <FormField.Input label={code} onChange={setCode} placeholder={placeholder} />
+        <Button
+          label="참여하기"
+          type="small"
+          onClick={() => onSubmit(code)}
+          disabled={code.length <= 0}
+        />
       </SubmitContainer>
     </Container>
   );

--- a/src/components/debug/TokenCookieManager.tsx
+++ b/src/components/debug/TokenCookieManager.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useEffect } from "react";
+import { withDevOnly } from "./withDevOnly";
+
+interface TokenInputProps {
+  style?: React.CSSProperties;
+}
+
+/**
+ * TokenCookieManager 컴포넌트는 개발 전용 컴포넌트입니다.
+ */
+const TokenCookieManager: React.FC<TokenInputProps> = withDevOnly(({ style }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [tokenInputs, setTokenInputs] = useState({
+    accessToken: "",
+    refreshToken: "",
+  });
+
+  useEffect(() => {
+    // 초기 쿠키 값 로드
+    const currentAccessToken = getCookie("accessToken") || "";
+    const currentRefreshToken = getCookie("refreshToken") || "";
+
+    setTokenInputs({
+      accessToken: currentAccessToken,
+      refreshToken: currentRefreshToken,
+    });
+  }, []);
+
+  const setCookie = (name: string, value: string) => {
+    document.cookie = `${name}=${value};`;
+  };
+
+  const getCookie = (name: string): string | null => {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+
+    if (parts.length === 2) return parts.pop()?.split(";").shift() || null;
+
+    return null;
+  };
+
+  const handleTokenChange = (type: "accessToken" | "refreshToken", value: string) => {
+    setTokenInputs((prev) => ({
+      ...prev,
+      [type]: value,
+    }));
+  };
+
+  const handleApplyTokens = () => {
+    const expiresAccess = new Date();
+    const expiresRefresh = new Date();
+
+    // Access Token은 3시간 후 만료
+    expiresAccess.setHours(expiresAccess.getHours() + 3);
+    // Refresh Token은 2주 후 만료
+    expiresRefresh.setDate(expiresRefresh.getDate() + 14);
+
+    if (tokenInputs.accessToken) {
+      setCookie("accessToken", tokenInputs.accessToken);
+    }
+
+    if (tokenInputs.refreshToken) {
+      setCookie("refreshToken", tokenInputs.refreshToken);
+    }
+
+    alert("토큰이 성공적으로 적용되었습니다.");
+  };
+
+  const handleClearTokens = () => {
+    setCookie("accessToken", "");
+    setCookie("refreshToken", "");
+    setTokenInputs({
+      accessToken: "",
+      refreshToken: "",
+    });
+    alert("토큰이 삭제되었습니다.");
+  };
+
+  const containerStyle: React.CSSProperties = {
+    position: "fixed",
+    bottom: "20px",
+    right: "20px",
+    zIndex: 9999,
+    backgroundColor: "rgba(0, 0, 0, 0.9)",
+    padding: "15px",
+    borderRadius: "8px",
+    color: "white",
+    width: "400px",
+    ...style,
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "8px",
+    marginTop: "5px",
+    backgroundColor: "#2b2b2b",
+    border: "1px solid #444",
+    color: "white",
+    borderRadius: "4px",
+    fontFamily: "monospace",
+    fontSize: "12px",
+  };
+
+  const buttonStyle: React.CSSProperties = {
+    padding: "8px 16px",
+    margin: "5px",
+    border: "none",
+    borderRadius: "4px",
+    cursor: "pointer",
+    fontWeight: "bold",
+  };
+
+  return (
+    <div style={containerStyle}>
+      <button
+        style={{ ...buttonStyle, backgroundColor: "#4CAF50" }}
+        onClick={() => setIsOpen(!isOpen)}>
+        {isOpen ? "토큰 설정 닫기" : "토큰 설정 열기"}
+      </button>
+
+      {isOpen && (
+        <div style={{ marginTop: "10px" }}>
+          {/* Access Token */}
+          <div style={{ marginBottom: "10px" }}>
+            <label>Access Token:</label>
+            <textarea
+              style={{ ...inputStyle, height: "60px" }}
+              value={tokenInputs.accessToken}
+              onChange={(e) => handleTokenChange("accessToken", e.target.value)}
+              placeholder="Access Token을 입력하세요"
+            />
+          </div>
+
+          {/* Refresh Token */}
+          <div style={{ marginBottom: "10px" }}>
+            <label>Refresh Token:</label>
+            <textarea
+              style={{ ...inputStyle, height: "60px" }}
+              value={tokenInputs.refreshToken}
+              onChange={(e) => handleTokenChange("refreshToken", e.target.value)}
+              placeholder="Refresh Token을 입력하세요"
+            />
+          </div>
+
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <button
+              style={{ ...buttonStyle, backgroundColor: "#2196F3" }}
+              onClick={handleApplyTokens}>
+              토큰 적용
+            </button>
+            <button
+              style={{ ...buttonStyle, backgroundColor: "#f44336" }}
+              onClick={handleClearTokens}>
+              토큰 삭제
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default TokenCookieManager;

--- a/src/components/debug/withDevOnly.tsx
+++ b/src/components/debug/withDevOnly.tsx
@@ -1,0 +1,7 @@
+export const withDevOnly = <P extends object>(Component: React.ComponentType<P>) => {
+  const isDevelopment = import.meta.env.MODE === "development";
+
+  return (props: P) => {
+    return isDevelopment ? <Component {...props} /> : null;
+  };
+};

--- a/src/pages/Main/containers/MyPlannerCardListContainer.tsx
+++ b/src/pages/Main/containers/MyPlannerCardListContainer.tsx
@@ -1,0 +1,40 @@
+import MyPlannerCardList from "@components/cardList/MyPlannerCardList";
+
+const MyPlannerCardListContainer = () => {
+  return <MyPlannerCardList items={mock} onEmptyCardClick={() => {}} />;
+};
+
+export default MyPlannerCardListContainer;
+
+const mock = [
+  {
+    country: "KOREA",
+    startDate: "2024.11.24",
+    endDate: "2024.11.30",
+    onClick: () => {},
+  },
+  {
+    country: "JAPAN",
+    startDate: "2025.01.01",
+    endDate: "2025.01.07",
+    onClick: () => {},
+  },
+  {
+    country: "CHINA",
+    startDate: "2025.02.01",
+    endDate: "2025.02.07",
+    onClick: () => {},
+  },
+  {
+    country: "JAPAN",
+    startDate: "2025.03.01",
+    endDate: "2025.03.07",
+    onClick: () => {},
+  },
+  {
+    country: "KOREA",
+    startDate: "2025.11.24",
+    endDate: "2025.11.30",
+    onClick: () => {},
+  },
+];

--- a/src/pages/Main/containers/StartPlannerCardContainer.tsx
+++ b/src/pages/Main/containers/StartPlannerCardContainer.tsx
@@ -1,0 +1,17 @@
+import { useTypedNavigate } from "@common/hooks/useTypedNavigate";
+import StartPlannerCard from "@components/card/StartPlannerCard";
+
+const StartPlannerCardContainer = () => {
+  const placeholder = "Room ID";
+  const navigate = useTypedNavigate();
+
+  return (
+    <StartPlannerCard
+      onClickPlanner={() => navigate("/createModalRoom")}
+      onSubmit={() => navigate("/enterModalRoom")}
+      placeholder={placeholder}
+    />
+  );
+};
+
+export default StartPlannerCardContainer;

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,18 +1,20 @@
 import styled from "styled-components";
 
 import { calcResponsive } from "@common/styles/theme";
-import MyPlannerCardList from "@components/cardList/MyPlannerCardList";
-import StartPlannerCard from "@components/card/StartPlannerCard";
 import Header from "@components/header/Header";
+import StartPlannerCardContainer from "./containers/StartPlannerCardContainer";
+import MyPlannerCardListContainer from "./containers/MyPlannerCardListContainer";
+import TokenCookieManager from "@components/debug/TokenCookieManager";
 
 const Main = () => {
   return (
     <>
       <Header />
       <Container>
-        <MyPlannerCardList items={mock} onEmptyCardClick={() => {}} />
-        <StartPlannerCard onClickPlanner={() => {}} onSubmit={() => {}} />
+        <MyPlannerCardListContainer />
+        <StartPlannerCardContainer />
       </Container>
+      <TokenCookieManager />
     </>
   );
 };
@@ -32,36 +34,3 @@ const Container = styled.div`
 `;
 
 export default Main;
-
-const mock = [
-  {
-    country: "KOREA",
-    startDate: "2024.11.24",
-    endDate: "2024.11.30",
-    onClick: () => {},
-  },
-  {
-    country: "JAPAN",
-    startDate: "2025.01.01",
-    endDate: "2025.01.07",
-    onClick: () => {},
-  },
-  {
-    country: "CHINA",
-    startDate: "2025.02.01",
-    endDate: "2025.02.07",
-    onClick: () => {},
-  },
-  {
-    country: "JAPAN",
-    startDate: "2025.03.01",
-    endDate: "2025.03.07",
-    onClick: () => {},
-  },
-  {
-    country: "KOREA",
-    startDate: "2025.11.24",
-    endDate: "2025.11.30",
-    onClick: () => {},
-  },
-];

--- a/src/pages/Modal/RoomCreateModal.tsx
+++ b/src/pages/Modal/RoomCreateModal.tsx
@@ -1,0 +1,5 @@
+const RoomCreateModal = () => {
+  return <div>RoomCreateModal</div>;
+};
+
+export default RoomCreateModal;

--- a/src/pages/Modal/RoomEnterModal.tsx
+++ b/src/pages/Modal/RoomEnterModal.tsx
@@ -1,0 +1,5 @@
+const RoomEnterModal = () => {
+  return <div>RoomEnterModal</div>;
+};
+
+export default RoomEnterModal;

--- a/src/pages/Modal/index.ts
+++ b/src/pages/Modal/index.ts
@@ -1,0 +1,2 @@
+export { default as RoomCreateModal } from "./RoomCreateModal";
+export { default as RoomEnterModal } from "./RoomEnterModal";

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,14 +1,18 @@
 import { createBrowserRouter } from "react-router-dom";
 
 import { Main, NotFound, Login, My, Planner, Landing } from "pages";
+import { ROUTES } from "./type";
+import { RoomCreateModal, RoomEnterModal } from "@pages/Modal";
 
 const router = createBrowserRouter([
-  { path: "/", element: <Main /> }, // 메인 페이지
-  { path: "/login", element: <Login /> }, // 로그인 페이지
-  { path: "/my", element: <My /> }, // 마이 페이지
-  { path: "/planner", element: <Planner /> }, // 플레너 페이지
-  { path: "/landing", element: <Landing /> }, // 404 페이지
-  { path: "*", element: <NotFound /> }, // 404 페이지
+  { path: ROUTES.MAIN, element: <Main /> },
+  { path: ROUTES.LOGIN, element: <Login /> },
+  { path: ROUTES.MY, element: <My /> },
+  { path: ROUTES.PLANNER, element: <Planner /> },
+  { path: ROUTES.LANDING, element: <Landing /> },
+  { path: ROUTES.CREATE_MODAL, element: <RoomCreateModal /> },
+  { path: ROUTES.ENTER_MODAL, element: <RoomEnterModal /> },
+  { path: "*", element: <NotFound /> },
 ]);
 
 export default router;

--- a/src/routes/type.ts
+++ b/src/routes/type.ts
@@ -1,0 +1,19 @@
+export const ROUTES = {
+  MAIN: "/",
+  LOGIN: "/login",
+  MY: "/my",
+  PLANNER: "/planner",
+  LANDING: "/landing",
+  CREATE_MODAL: "/createModalRoom",
+  ENTER_MODAL: "/enterModalRoom",
+} as const;
+
+export type RouteParams = {
+  [ROUTES.MAIN]: undefined;
+  [ROUTES.LOGIN]: undefined;
+  [ROUTES.MY]: undefined;
+  [ROUTES.PLANNER]: undefined;
+  [ROUTES.LANDING]: undefined;
+  [ROUTES.CREATE_MODAL]: undefined;
+  [ROUTES.ENTER_MODAL]: undefined;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,5 +14,13 @@ export default defineConfig(({ mode }) => {
       __VITE_MSW_ENABLED__: JSON.stringify(env.VITE_MSW_ENABLED),
     },
     assetsInclude: ["./src/assets/fonts/Ticketing-Regular.otf"],
+    server: {
+      proxy: {
+        "/api": {
+          target: env.VITE_API_URL,
+          changeOrigin: true,
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 쿠키 내용을 설정해서 API 요청이 가능하도록 만들었습니다.
- 네비게이터 사용 시 파라미터와 매개변수 타입 추론이 가능한 타입 가드를 만들었습니다.

## 📝 요구 사항과 구현 내용
- 네비게이터 타입 가드
- 메인페이지 레이어 계층 분리

## 💬 PR 포인트 & 궁금한 점
- 토큰을 명시적으로 작성해서 쿠키 설정 후 API 요청 시 해당 쿠키를 같이 전송하도록 하는 개발 전용 컴포넌트를 만들었습니다.
- `useTypedNavigate`, `useTypedParams`을 사용하시면 됩니다.

## 🔗 연관된 이슈
- #39 